### PR TITLE
Bugfixes for api version/url and regexps

### DIFF
--- a/config/cartodb.nginx.proxy.conf
+++ b/config/cartodb.nginx.proxy.conf
@@ -3,7 +3,7 @@ server {
 
   client_max_body_size 100M;
 
-  location ^~ /(user/.*/)?api/v1/maps {
+  location ~* /(user/.*/)?api/v1/maps {
     proxy_set_header        Host $host;
     proxy_set_header        X-Real-IP $remote_addr;
     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -11,7 +11,7 @@ server {
     proxy_pass http://127.0.0.1:3000;
   }
 
-  location ^~ /(user/.*/)?api/v1/map {
+  location ~* /(user/.*/)?api/v1/map {
     proxy_set_header        Host $host;
     proxy_set_header        X-Real-IP $remote_addr;
     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -19,7 +19,9 @@ server {
     proxy_pass http://127.0.0.1:8181;
   }
 
-  location ^~ /(user/.*/)?/api/v2/sql {
+  location ~* /(user/.*)?/api/v2/sql {
+    # RedHog: Hack to work around bug in cartodb local hosting but using cdn for js libs
+    rewrite /(user/.*)?/api/v2/sql(.*) /$1/api/v2/sql$2  break;
     proxy_set_header        Host $host;
     proxy_set_header        X-Real-IP $remote_addr;
     proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;


### PR DESCRIPTION
This pull request fixes two things:

* A misunderstanding over the meaning of the ^~ location option in nginx
* An api version issue that made CDN-loaded cartodb.js unable to load maps
