### PR TITLE
Fix unreachable RVM url

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,9 +123,9 @@ RUN cd /opt && \
     rm -rf /opt/ogr2ogr2 /opt/gdal-2.1.1.tar.gz /root/.gitconfig /opt/gdal-2.1.1
 
 # Install NodeJS
-RUN curl https://nodejs.org/download/release/v0.10.41/node-v0.10.41-linux-x64.tar.gz| tar -zxf - --strip-components=1 -C /usr && \
+RUN curl https://nodejs.org/download/release/v6.9.2/node-v6.9.2-linux-x64.tar.gz| tar -zxf - --strip-components=1 -C /usr && \
   npm install -g grunt-cli && \
-  npm install -g npm@~2.14.0 && \
+  npm install -g npm@3.10.9 && \
   rm -r /tmp/npm-* /root/.npm
 
 # Install rvm

--- a/Dockerfile
+++ b/Dockerfile
@@ -130,7 +130,7 @@ RUN curl https://nodejs.org/download/release/v0.10.41/node-v0.10.41-linux-x64.ta
 
 # Install rvm
 RUN gpg --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3 && \
-    curl -L https://get.rvm.io | bash -s stable --ruby && \
+    curl -sSL https://raw.githubusercontent.com/wayneeseguin/rvm/stable/binscripts/rvm-installer | bash -s stable --ruby && \
     echo 'source /usr/local/rvm/scripts/rvm' >> /etc/bash.bashrc && \
     /bin/bash -l -c rvm requirements
 ENV PATH /usr/local/rvm/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin


### PR DESCRIPTION
Hi, 

The patch fixes the unreachable URL get.rvm.io for bash -s stable flag enabled. The stable url points elsewhere which is what I've updated below

Note: I've started working on this project, as a continuation of my bid for your job posted on freelancer.com. Here is my freelancer profile. 
https://www.freelancer.com/u/srirammax.html?ref_project_id=14435302

Let me know if this is useful. I'll continue the work. 

Signed-off-by: Sriram Raghunathan <sriram@marirs.net.in>