### PR TITLE
Specify bundler version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -187,7 +187,7 @@ RUN git clone --recursive git://github.com/CartoDB/cartodb.git && \
     rm -r /tmp/npm-* /root/.npm && \
     perl -pi -e 's/gdal==1\.10\.0/gdal==2.2.2/' python_requirements.txt && \
     pip install --no-binary :all: -r python_requirements.txt && \
-    gem install bundler bundle compass archive-tar-minitar rack && \
+    gem install bundler --version=1.17.3 && gem install compass archive-tar-minitar rack && \
     bundle update thin && \
     /bin/bash -l -c 'bundle install' && \
     cp config/grunt_development.json ./config/grunt_true.json && \


### PR DESCRIPTION
Before, the Dockerfile was installing the latest bundler version, which is only compatible with Ruby >= 2.3.0. I've changed the bundler version to 1.17.3, which requires Ruby >= 1.8.7. Version info here: https://rubygems.org/gems/bundler/versions/1.17.3