### PR TITLE
Update Dockerfile with npm install, not yarn

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -169,7 +169,7 @@ RUN git clone git://github.com/CartoDB/CartoDB-SQL-API.git && \
 RUN git clone git://github.com/CartoDB/Windshaft-cartodb.git && \
     cd Windshaft-cartodb && \
     git checkout $WINDSHAFT_VERSION && \
-    yarn install && \
+    npm install && \
     mkdir logs
 
 # Install CartoDB


### PR DESCRIPTION
Windsfhaft Carto version 7.0.0 released 2019-02-22, introduces breaking changes:

    Drop support for Node.js 6
    Drop support for npm 3
    Stop supporting yarn.lock
    Drop support for Postgres 9.5
    Drop support for PosGIS 2.2
    Drop support for Redis 3

Revision to yarn install to npm install resolves issue with extension loading. 