### PR TITLE
Update caching

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -221,7 +221,7 @@ ADD ./config/app_config.yml /cartodb/config/app_config.yml
 ADD ./config/database.yml /cartodb/config/database.yml
 ADD ./create_dev_user /cartodb/script/create_dev_user
 ADD ./setup_organization.sh /cartodb/script/setup_organization.sh
-ADD ./config/cartodb.nginx.proxy.conf /etc/nginx/sites-enabled/default
+ADD ./config/cartodb.nginx.proxy.conf /etc/nginx/nginx.conf
 ADD ./config/varnish.vcl /etc/varnish.vcl
 ADD ./geocoder.sh /cartodb/script/geocoder.sh
 ADD ./geocoder_server.sql /cartodb/script/geocoder_server.sql

--- a/config/app_config.yml
+++ b/config/app_config.yml
@@ -163,14 +163,14 @@ defaults: &defaults
     timeout: 5
     # 'warning' or 'error'
     trigger_verbose: true
-  invalidation_service:
-    enabled: false
-    host: '127.0.0.1'
-    port: 3142
-    retries: 5 # number of retries before considering failure
-    critical: false # either the failure is considered an error or a warning
-    timeout: 5 # socket timeout
-    trigger_verbose: true
+#  invalidation_service:
+#    enabled: false
+#    host: '127.0.0.1'
+#    port: 3142
+#    retries: 5 # number of retries before considering failure
+#    critical: false # either the failure is considered an error or a warning
+#    timeout: 5 # socket timeout
+#    trigger_verbose: true
   redis:
     host: '127.0.0.1'
     port: 6379

--- a/config/cartodb.nginx.proxy.conf
+++ b/config/cartodb.nginx.proxy.conf
@@ -1,46 +1,80 @@
-server {
-  server_name cartodb.localhost *.cartodb.localhost;
+user www-data;
+worker_processes auto;
+pid /run/nginx.pid;
+include /etc/nginx/modules-enabled/*.conf;
 
-  client_max_body_size 0;
+events {
+    worker_connections 768;
+}
 
-  location ~* /(user/.*/)?api/v1/maps {
-    proxy_set_header        Host $host;
-    proxy_set_header        X-Real-IP $remote_addr;
-    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header        X-Forwarded-Proto $scheme;
-    proxy_pass http://127.0.0.1:3000;
-  }
+http {
+    sendfile            on;
+    tcp_nopush          on;
+    tcp_nodelay         on;
+    keepalive_timeout   65;
+    types_hash_max_size 2048;
+    include             /etc/nginx/mime.types;
+    default_type        application/octet-stream;
 
-  location ~* /(user/.*/)?api/v1/map {
-    proxy_set_header        Host $host;
-    proxy_set_header        X-Real-IP $remote_addr;
-    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header        X-Forwarded-Proto $scheme;
-    proxy_pass http://127.0.0.1:8181;
-  }
+    ssl_protocols               TLSv1 TLSv1.1 TLSv1.2; # Dropping SSLv3, ref: POODLE
+    ssl_prefer_server_ciphers   on;
 
-  location ~* /(user/.*)?/api/v2/sql {
-    # RedHog: Hack to work around bug in cartodb local hosting but using cdn for js libs
-    rewrite /(user/.*)?/api/v2/sql(.*) /$1/api/v2/sql$2  break;
-    proxy_set_header        Host $host;
-    proxy_set_header        X-Real-IP $remote_addr;
-    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header        X-Forwarded-Proto $scheme;
-    proxy_pass http://127.0.0.1:8080;
-  }
+    access_log  /var/log/nginx/access.log;
+    error_log   /var/log/nginx/error.log;
 
-  location ^~ /assets {
-    root /cartodb/public;
-  }
+    log_format main '[$time_local] $status REQUEST: "$request" REFERER: "$http_referer" FWD_FOR "$http_x_forwarded_for" PROXY_HOST: "$proxy_host" UPSTREAM_ADDR: "$upstream_addr"';
 
-  location / {
-    proxy_set_header        Host $host;
-    proxy_set_header        X-Real-IP $remote_addr;
-    proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
-    proxy_set_header        X-Forwarded-Proto $scheme;
-    proxy_pass http://127.0.0.1:3000;
-  }
+    gzip on;
 
-  error_log /var/log/nginx/cartodb_error.log;
-  access_log /var/log/nginx/cartodb_access.log;
+    server {
+      server_name           cartodb.localhost *.cartodb.localhost;
+      client_max_body_size  0;
+
+      location ~* /(user/.*/)?api/v1/maps {
+        proxy_set_header        Host $host;
+        proxy_set_header        X-Real-IP $remote_addr;
+        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_pass              http://127.0.0.1:3000;
+      }
+
+      location ~* /(user/.*/)?api/v1/map {
+        proxy_set_header        Host $host;
+        proxy_set_header        X-Real-IP $remote_addr;
+        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Carto-Service windshaft; # tell varnish what backend
+        proxy_no_cache          true;           # Make sure nginx doesn't cache
+        proxy_cache_bypass      true;           # Make sure nginx doesn't cache
+        proxy_pass              http://127.0.0.1:6081;  # hand off to Varnish
+      }
+
+      location ~* /(user/.*/)?api/v2/sql {
+        # RedHog: Hack to work around bug in cartodb local hosting but using cdn for js libs
+        rewrite /(user/.*)?/api/v2/sql(.*) /$1/api/v2/sql$2  break;
+        proxy_set_header        Host $host;
+        proxy_set_header        X-Real-IP $remote_addr;
+        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_set_header        X-Carto-Service sqlapi; # tell varnish what backend
+        proxy_no_cache          true;           # make sure nginx doesn't cache
+        proxy_cache_bypass      true;           # make sure nginx doesn't cache
+        proxy_pass              http://127.0.0.1:6081;  # hand off to Varnish
+      }
+
+      location ^~ /assets {
+        root /cartodb/public;
+      }
+
+      location / {
+        proxy_set_header        Host $host;
+        proxy_set_header        X-Real-IP $remote_addr;
+        proxy_set_header        X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header        X-Forwarded-Proto $scheme;
+        proxy_pass http://127.0.0.1:3000;
+      }
+
+      error_log /var/log/nginx/cartodb_error.log;
+      access_log /var/log/nginx/cartodb_access.log main;
+    }
 }

--- a/config/varnish.vcl
+++ b/config/varnish.vcl
@@ -1,4 +1,48 @@
-backend default {
-  .host = "127.0.0.1";
-  .port = "8080";
+acl purge {
+    "localhost";
+    "127.0.0.1";
+}
+
+backend sqlapi {
+    .host = "127.0.0.1";
+    .port = "8080";
+}
+
+backend windshaft {
+    .host = "127.0.0.1";
+    .port = "8181";
+}
+
+sub vcl_recv {
+    # Allowing PURGE from localhost
+    if (req.request == "PURGE") {
+        if (!client.ip ~ purge) {
+            error 405 "Not allowed.";
+        }
+        return (lookup);
+    }
+
+    # Routing request to backend based on X-Carto-Service header from nginx
+    if (req.http.X-Carto-Service == "sqlapi") {
+        set req.backend = sqlapi;
+        remove req.http.X-Carto-Service;
+    }
+    if (req.http.X-Carto-Service == "windshaft") {
+        set req.backend = windshaft;
+        remove req.http.X-Carto-Service;
+    }
+}
+
+sub vcl_hit {
+    if (req.request == "PURGE") {
+        purge;
+        error 200 "Purged.";
+    }
+}
+
+sub vcl_miss {
+    if (req.request == "PURGE") {
+        purge;
+        error 200 "Purged.";
+    }
 }

--- a/startup.sh
+++ b/startup.sh
@@ -2,7 +2,7 @@
 
 export CARTO_HOSTNAME=${CARTO_HOSTNAME:=$HOSTNAME}
 
-perl -pi -e 's/cartodb\.localhost/$ENV{"CARTO_HOSTNAME"}/g' /etc/nginx/sites-enabled/default /cartodb/config/app_config.yml /Windshaft-cartodb/config/environments/development.js
+perl -pi -e 's/cartodb\.localhost/$ENV{"CARTO_HOSTNAME"}/g' /etc/nginx/nginx.conf /cartodb/config/app_config.yml /Windshaft-cartodb/config/environments/development.js
 
 PGDATA=/var/lib/postgresql
 if [ "$(stat -c %U $PGDATA)" != "postgres" ]; then


### PR DESCRIPTION
Hi!

I was using your image to troubleshoot some configuration in [the multi-container Carto repo](https://github.com/ruralinnovation/multi-svc-cartodb) I'm working on, and noticed that Varnish as configured wasn't actually receiving traffic. This PR has Nginx and Varnish config changes that set Varnish up to cache both the SQL API and Windshaft. It also explicitly forces Nginx _not_ to cache those requests, which it tends to do by default (potentially creating two layers of caching, with lots of phantom HTTP 304 bugs as a result). There are more descriptive details in the commit messages, and feel free to @ me if anything is unclear.

A few helpful commands (to run on the container) for testing this out:

* `tail -f /var/log/nginx/cartodb_access.log`
* `/opt/varnish/bin/varnishlog -c` - _shows Varnish logs for requests from the client_
* `tail -f /CartoDB-SQL-API/logs/cartodb-sql-api.log`

If you run those in separate sessions and then make a new request that hits the SQL API, you should be able to see the request get proxied by Nginx, passed to Varnish, then passed on to the SQL API itself. A subsequent request for the same resource should (barring things like using the `Authorization` header, which will cause Varnish to automatically pass the request) hit Nginx and Varnish, but not make it all the way to the SQL API.

Also, if you keep the varnish logging process open while making style changes to a visualization in the Builder interface, you will see PURGE requests being processed by Varnish, based on HTTP calls made by the invalidation logic in the postgres trigger created by the code here:

https://github.com/CartoDB/cartodb/blob/05a05fd6959bf4cc42480daec08d28449532cd8e/app/models/user/db_service.rb#L1491-L1538

Hope this is useful,

Nick