### PR TITLE
Unset cookie so that varnish can cache requests

### DIFF
--- a/config/varnish.vcl
+++ b/config/varnish.vcl
@@ -21,6 +21,8 @@ sub vcl_recv {
         }
         return (lookup);
     }
+    
+    unset req.http.cookie;
 
     # Routing request to backend based on X-Carto-Service header from nginx
     if (req.http.X-Carto-Service == "sqlapi") {


### PR DESCRIPTION
Varnish doesn't cache requests with the cookie because each one has another cookie